### PR TITLE
Fix room name topic / display for long rooms

### DIFF
--- a/syweb/webclient/app/app.css
+++ b/syweb/webclient/app/app.css
@@ -467,7 +467,6 @@ textarea, input {
 
 .roomNameSection, .roomTopicSection {
     text-align: right;
-    float: right;
     width: 100%;
 }
 


### PR DESCRIPTION
Fix to stop room name & topic dropping down to be underneath the chat window when it gets long.

Does this look sensible?