### PR TITLE
Add broadcast of incoming state events.

### DIFF
--- a/syweb/webclient/app/components/matrix/event-handler-service.js
+++ b/syweb/webclient/app/components/matrix/event-handler-service.js
@@ -95,6 +95,7 @@ function(matrixService, $rootScope, $window, $q, $timeout, $filter, mPresence, n
                 }
             }
         }
+        $rootScope.$broadcast(eventHandlerService.STATE_EVENT, event, isLiveEvent);
         // TODO: handle old_room_state
     };
     
@@ -311,6 +312,7 @@ function(matrixService, $rootScope, $window, $q, $timeout, $filter, mPresence, n
         NAME_EVENT: "NAME_EVENT",
         TOPIC_EVENT: "TOPIC_EVENT",
         RESET_EVENT: "RESET_EVENT",  // eventHandlerService has been reset
+        STATE_EVENT: "STATE_EVENT",
         EVENT_ID_LIFETIME_MS: 1000 * 10, // lifetime of an event ID in the map is 10s
         
         reset: function() {


### PR DESCRIPTION
Add broadcast of state events on the rootscope. Makes it easier to use state events when building on top of the SDK.
