### PR TITLE
Make the Matrix services Protractor friendly

### DIFF
--- a/syweb/webclient/app/components/matrix/event-handler-service.js
+++ b/syweb/webclient/app/components/matrix/event-handler-service.js
@@ -26,8 +26,8 @@ Typically, this service will store events and broadcast them to any listeners
 (e.g. controllers) via $broadcast. 
 */
 angular.module('eventHandlerService', [])
-.factory('eventHandlerService', ['matrixService', '$rootScope', '$window', '$q', '$timeout', '$filter', 'mPresence', 'notificationService', 'modelService', 'commandsService',
-function(matrixService, $rootScope, $window, $q, $timeout, $filter, mPresence, notificationService, modelService, commandsService) {
+.factory('eventHandlerService', ['matrixService', '$rootScope', '$window', '$q', '$filter', 'mPresence', 'notificationService', 'modelService', 'commandsService', '$interval',
+function(matrixService, $rootScope, $window, $q, $filter, mPresence, notificationService, modelService, commandsService, $interval) {
     // used for dedupping events 
     var eventReapMap = {
     //  room_id: { event_id: time_seen }
@@ -69,7 +69,7 @@ function(matrixService, $rootScope, $window, $q, $timeout, $filter, mPresence, n
             }
         }
         
-        $timeout(reapOldEventIds, REAP_POLL_MS);
+        $interval(reapOldEventIds, REAP_POLL_MS, 1);
     };
     reapOldEventIds();
     
@@ -319,6 +319,7 @@ function(matrixService, $rootScope, $window, $q, $timeout, $filter, mPresence, n
         RESET_EVENT: "RESET_EVENT",  // eventHandlerService has been reset
         STATE_EVENT: "STATE_EVENT",
         EVENT_ID_LIFETIME_MS: 1000 * 10, // lifetime of an event ID in the map is 10s
+        REAP_POLL_MS: REAP_POLL_MS, // Expose for unit testing
         
         reset: function() {
             reset();

--- a/syweb/webclient/app/components/matrix/matrix-call.js
+++ b/syweb/webclient/app/components/matrix/matrix-call.js
@@ -36,8 +36,8 @@ var forAllTracksOnStream = function(s, f) {
 }
 
 angular.module('MatrixCall', [])
-.factory('MatrixCall', ['webRtcService', 'matrixService', 'matrixPhoneService', 'modelService', '$rootScope', '$timeout', 
-function MatrixCallFactory(webRtcService, matrixService, matrixPhoneService, modelService, $rootScope, $timeout) {
+.factory('MatrixCall', ['webRtcService', 'matrixService', 'matrixPhoneService', 'modelService', '$rootScope', '$timeout', '$interval',
+function MatrixCallFactory(webRtcService, matrixService, matrixPhoneService, modelService, $rootScope, $timeout, $interval) {
 
     var MatrixCall = function(room_id) {
         this.room_id = room_id;
@@ -63,7 +63,7 @@ function MatrixCallFactory(webRtcService, matrixService, matrixPhoneService, mod
                 MatrixCall.turnServer = response.data;
                 $rootScope.haveTurn = true;
                 // re-fetch when we're about to reach the TTL
-                $timeout(MatrixCall.getTurnServer, MatrixCall.turnServer.ttl * 1000 * 0.9);
+                $interval(MatrixCall.getTurnServer, MatrixCall.turnServer.ttl * 1000 * 0.9, 1);
             } else {
                 console.log("Got no TURN URIs from HS");
                 $rootScope.haveTurn = false;
@@ -393,11 +393,11 @@ function MatrixCallFactory(webRtcService, matrixService, matrixPhoneService, mod
             };
             self.sendEventWithRetry('m.call.invite', content);
 
-            $timeout(function() {
+            $interval(function() {
                 if (self.state == 'invite_sent') {
                     self.hangup('invite_timeout');
                 }
-            }, MatrixCall.CALL_TIMEOUT);
+            }, MatrixCall.CALL_TIMEOUT, 1);
             self.state = 'invite_sent';
         }, 
         function() { 

--- a/syweb/webclient/app/components/matrix/presence-service.js
+++ b/syweb/webclient/app/components/matrix/presence-service.js
@@ -21,8 +21,8 @@
  * Any state change will be sent to the Home Server.
  */
 angular.module('mPresence', [])
-.service('mPresence', ['$timeout', '$document', 'matrixService', 
-function ($timeout, $document, matrixService) {
+.service('mPresence', ['$document', 'matrixService', '$interval',
+function ($document, matrixService, $interval) {
 
     // Time in ms after that a user is considered as unavailable/away
     var UNAVAILABLE_TIME = 3 * 60000; // 3 mins
@@ -30,9 +30,11 @@ function ($timeout, $document, matrixService) {
     // The current presence state
     var state = undefined;
 
-    var self =this;
+    var self = this;
     var timer;
     
+    this.UNAVAILABLE_TIME = UNAVAILABLE_TIME; // Expose for unit testing
+
     /**
      * Start listening the user activity to evaluate his presence state.
      * Any state change will be sent to the Home Server.
@@ -52,7 +54,7 @@ function ($timeout, $document, matrixService) {
      */
     this.stop = function() {
         if (timer) {
-            $timeout.cancel(timer);
+            $interval.cancel(timer);
             timer = undefined;
         }
         state = undefined;
@@ -105,8 +107,8 @@ function ($timeout, $document, matrixService) {
         self.setState(matrixService.presence.online);
         
         // Re-arm the timer
-        $timeout.cancel(timer);
-        timer = $timeout(onUnvailableTimerFire, UNAVAILABLE_TIME);
+        $interval.cancel(timer);
+        timer = $interval(onUnvailableTimerFire, UNAVAILABLE_TIME, 1);
     }    
 
 }]);

--- a/syweb/webclient/app/components/matrix/typing-service.js
+++ b/syweb/webclient/app/components/matrix/typing-service.js
@@ -23,8 +23,8 @@ limitations under the License.
  * server poke (which when it times out means you need to re-poke).
  */
 angular.module('typingService', [])
-.factory('typingService', [ '$timeout', 'matrixService',
-function($timeout, matrixService) {
+.factory('typingService', [ 'matrixService', '$interval',
+function(matrixService, $interval) {
     var typingService = {};
 
     // canonical source for rooms typing in
@@ -42,17 +42,17 @@ function($timeout, matrixService) {
     var cancelUserTimeout = function(roomId) {
         var timerPromise = userTimeouts[roomId];
         if (timerPromise) {
-            $timeout.cancel(timerPromise);
+            $interval.cancel(timerPromise);
         }
     };
     var startUserTimeout = function(roomId) {
-        userTimeouts[roomId] = $timeout(function() {
+        userTimeouts[roomId] = $interval(function() {
             if (roomsTyping[roomId]) {
                 console.log("[typing] user-timeout: expired "+roomId);
                 roomsTyping[roomId] = false;
                 stopTyping(roomId);
             }
-        }, typingService.USER_TIMEOUT_MS);
+        }, typingService.USER_TIMEOUT_MS, 1);
     };
 
     // The "server timeout" is the time taken from the last server poke until another poke is required if they are still
@@ -65,11 +65,11 @@ function($timeout, matrixService) {
     var cancelServerTimeout = function(roomId) {
         var timerPromise = serverTimeouts[roomId];
         if (timerPromise) {
-            $timeout.cancel(timerPromise);
+            $interval.cancel(timerPromise);
         }
     };
     var startServerTimeout = function(roomId) {
-        serverTimeouts[roomId] = $timeout(function() {
+        serverTimeouts[roomId] = $interval(function() {
             console.log("[typing] server-timeout: expired. Still typing: "+roomsTyping[roomId]+" in room "+roomId);
             if (roomsTyping[roomId]) {
                 startServerTimeout(roomId);
@@ -81,7 +81,7 @@ function($timeout, matrixService) {
                     console.error("[typing] server-timeout: Unable to re-poke typing notification.");
                 });
             }
-        }, typingService.SERVER_TIMEOUT_MS);
+        }, typingService.SERVER_TIMEOUT_MS, 1);
     };
 
 

--- a/syweb/webclient/test/unit/event-handler-service.spec.js
+++ b/syweb/webclient/test/unit/event-handler-service.spec.js
@@ -1,5 +1,5 @@
 describe('EventHandlerService', function() {
-    var scope, q, timeout, _window;
+    var scope, $q, $interval, $window;
     
     var testContainsBingWords, testPresenceState, testRoomName; // mPresence, mRoomNameFilter, notificationService
     var testUserId, testDisplayName, testBingWords; // matrixService.config
@@ -73,7 +73,7 @@ describe('EventHandlerService', function() {
     
     var matrixService = {
         resolveRoomAlias: function(alias) {
-            var defer = q.defer();
+            var defer = $q.defer();
             if (testResolvedRoomId) {
                 defer.resolve({ data: { room_id: testResolvedRoomId} });
             }
@@ -83,7 +83,7 @@ describe('EventHandlerService', function() {
             return defer.promise;
         },
         join: function(roomId) {
-            var defer = q.defer();
+            var defer = $q.defer();
             if (testJoinSuccess) {
                 defer.resolve({});
             }
@@ -93,7 +93,7 @@ describe('EventHandlerService', function() {
             return defer.promise;
         },
         roomInitialSync: function(roomId) {
-            var defer = q.defer();
+            var defer = $q.defer();
             if (testRoomInitialSync) {
                 defer.resolve({ data: testRoomInitialSync });
             }
@@ -106,7 +106,7 @@ describe('EventHandlerService', function() {
             return testConfig;
         },
         sendTextMessage: function(roomId, input) {
-            var defer = q.defer();
+            var defer = $q.defer();
             if (testSendMessage) {
                 defer.resolve({ data: testSendMessage });
             }
@@ -143,13 +143,13 @@ describe('EventHandlerService', function() {
     var mRoomNameFilter = function(){
         return function() {
             return testRoomName;
-        }
+        };
     };
     
     var mUserDisplayNameFilter = function() {
         return function(input) {
             return input;
-        }
+        };
     };
     
     // helper function
@@ -274,11 +274,11 @@ describe('EventHandlerService', function() {
         module('eventHandlerService');
     });
     
-    beforeEach(inject(function($rootScope, $q, $timeout, $window) {
+    beforeEach(inject(function($rootScope, _$q_, _$interval_, _$window_) {
         scope = $rootScope;
-        q = $q;
-        timeout = $timeout;
-        _window = $window;
+        $q = _$q_;
+        $interval = _$interval_;
+        $window = _$window_;
     }));
 
     it('joinRoom: should be able to join a room from a room ID.', inject(
@@ -685,11 +685,11 @@ describe('EventHandlerService', function() {
         var testTime = new Date().getTime() + 
                        eventHandlerService.EVENT_ID_LIFETIME_MS + 1000;
         var oldDate = Date;
-        spyOn(window, 'Date').and.callFake(function() {
+        spyOn($window, 'Date').and.callFake(function() {
             return new oldDate(testTime);
         });
         
-        timeout.flush(); // force a recheck
+        $interval.flush(eventHandlerService.REAP_POLL_MS); // force a recheck
         
         // should not suppress since it forgot about it.
         eventHandlerService.handleEvent(dupeEvent, true);
@@ -702,7 +702,7 @@ describe('EventHandlerService', function() {
         var isPublic = true;
         var invitee = "@alicia:matrix.org";
         var roomId = "!avauyga:matrix.org";
-        var defer = q.defer();
+        var defer = $q.defer();
         spyOn(matrixService, "create").and.returnValue(defer.promise);
         spyOn(matrixService, "roomInitialSync").and.callThrough();
         

--- a/syweb/webclient/test/unit/event-stream-service.spec.js
+++ b/syweb/webclient/test/unit/event-stream-service.spec.js
@@ -1,16 +1,16 @@
 describe('EventStreamService', function() {
-    var q, scope, timeout;
+    var $q, $scope, $interval;
 
     var testInitialSync, testEventStream;
 
     var matrixService = {
         initialSync: function(limit, feedback) {
-            var defer = q.defer();
+            var defer = $q.defer();
             defer.resolve(testInitialSync);
             return defer.promise;
         },
         getEventStream: function(from, svrTimeout, cliTimeout) {
-            var defer = q.defer();
+            var defer = $q.defer();
             defer.resolve(testEventStream);
             return defer.promise;
         }
@@ -55,10 +55,10 @@ describe('EventStreamService', function() {
         module('eventStreamService');
     });
     
-    beforeEach(inject(function($q, $rootScope, $timeout) {
-        q = $q;
-        scope = $rootScope;
-        timeout = $timeout;
+    beforeEach(inject(function(_$q_, _$rootScope_, _$interval_) {
+        $q = _$q_;
+        $scope = _$rootScope_;
+        $interval = _$interval_;
     }));
 
     it('should start with /initialSync then go onto /events', inject(
@@ -66,7 +66,7 @@ describe('EventStreamService', function() {
         spyOn(eventHandlerService, "handleInitialSyncDone");
         spyOn(eventHandlerService, "handleEvents");
         eventStreamService.resume();
-        scope.$digest(); // initialSync request
+        $scope.$digest(); // initialSync request
         expect(eventHandlerService.handleInitialSyncDone).toHaveBeenCalledWith(testInitialSync);
         expect(eventHandlerService.handleEvents).toHaveBeenCalledWith(testEventStream.data.chunk, true);
     }));
@@ -75,7 +75,7 @@ describe('EventStreamService', function() {
     function(eventStreamService) {
         spyOn(matrixService, "getEventStream").and.callThrough();
         eventStreamService.resume();
-        scope.$digest(); // initialSync request
+        $scope.$digest(); // initialSync request
         expect(matrixService.getEventStream).toHaveBeenCalledWith("foo", eventStreamService.SERVER_TIMEOUT, jasmine.any(Object));
     }));
     
@@ -83,7 +83,7 @@ describe('EventStreamService', function() {
     function(eventStreamService) {
         var timeout = undefined; // this is the promise provided to $http.timeout
         var timeoutResolved = false; // flag to see if the cancel request was made
-        var request = q.defer().promise; // the http request which we're blocking on
+        var request = $q.defer().promise; // the http request which we're blocking on
         spyOn(matrixService, "getEventStream").and.callFake(function(from, timeoutMs, promise) {
             timeout = promise;
             timeout.then(function(r){
@@ -92,11 +92,11 @@ describe('EventStreamService', function() {
             return request;
         });
         eventStreamService.resume();
-        scope.$digest(); // initialSync request
+        $scope.$digest(); // initialSync request
         expect(timeout).toBeDefined();
         expect(timeoutResolved).toBeFalsy();
         eventStreamService.pause();
-        scope.$digest(); // resolving the timeout
+        $scope.$digest(); // resolving the timeout
         expect(timeoutResolved).toBeTruthy();
         
     }));
@@ -105,7 +105,7 @@ describe('EventStreamService', function() {
     function(eventStreamService) {
         var timeout = undefined; // this is the promise provided to $http.timeout
         var timeoutResolved = false; // flag to see if the cancel request was made
-        var request = q.defer().promise; // the http request which we're blocking on
+        var request = $q.defer().promise; // the http request which we're blocking on
         spyOn(matrixService, "getEventStream").and.callFake(function(from, timeoutMs, promise) {
             timeout = promise;
             timeout.then(function(r){
@@ -114,36 +114,36 @@ describe('EventStreamService', function() {
             return request;
         });
         eventStreamService.resume();
-        scope.$digest(); // initialSync request
+        $scope.$digest(); // initialSync request
         expect(timeout).toBeDefined();
         expect(timeoutResolved).toBeFalsy();
         eventStreamService.stop();
-        scope.$digest(); // resolving the timeout
+        $scope.$digest(); // resolving the timeout
         expect(timeoutResolved).toBeTruthy();
         
     }));
     
     it('should broadcast a bad connection if there are multiple failed attempts.', inject(
     function(eventStreamService) {
-        var request = q.defer(); // the http request which we're blocking on
+        var request = $q.defer(); // the http request which we're blocking on
         var timesCalled = 0;
         var isBadConnection = false;
         spyOn(matrixService, "getEventStream").and.callFake(function(from, timeoutMs, promise) {
             timesCalled += 1;
             return request.promise;
         });
-        scope.$on(eventStreamService.BROADCAST_BAD_CONNECTION, function(ngEvent, isBad) {
+        $scope.$on(eventStreamService.BROADCAST_BAD_CONNECTION, function(ngEvent, isBad) {
             isBadConnection = isBad;
         });
         
         eventStreamService.resume();
-        scope.$digest(); // initialSync request
+        $scope.$digest(); // initialSync request
         
-        for (var i=0; i<eventStreamService.MAX_FAILED_ATTEMPTS; i++) {
+        for (var i = 0; i < eventStreamService.MAX_FAILED_ATTEMPTS; i++) {
             request.reject({data:{status:0}}); // reject no connection.
-            request = q.defer(); // make a new promise in prep for the next request
-            scope.$digest(); // invoke the .then
-            timeout.flush(); // flush the waiting period.
+            request = $q.defer(); // make a new promise in prep for the next request
+            $scope.$digest(); // invoke the .then
+            $interval.flush(eventStreamService.SERVER_TIMEOUT + (1000 * 2)); // flush the waiting period.
         }
         
         expect(timesCalled).toBe(eventStreamService.MAX_FAILED_ATTEMPTS + 1);
@@ -153,33 +153,33 @@ describe('EventStreamService', function() {
     
     it('should broadcast a good connection if a successful attempt goes through after bad ones.', inject(
     function(eventStreamService) {
-        var request = q.defer(); // the http request which we're blocking on
+        var request = $q.defer(); // the http request which we're blocking on
         var timesCalled = 0;
         var isBadConnection = false;
         spyOn(matrixService, "getEventStream").and.callFake(function(from, timeoutMs, promise) {
             timesCalled += 1;
             return request.promise;
         });
-        scope.$on(eventStreamService.BROADCAST_BAD_CONNECTION, function(ngEvent, isBad) {
+        $scope.$on(eventStreamService.BROADCAST_BAD_CONNECTION, function(ngEvent, isBad) {
             isBadConnection = isBad;
         });
         
         eventStreamService.resume();
-        scope.$digest(); // initialSync request
+        $scope.$digest(); // initialSync request
         
-        for (var i=0; i<(eventStreamService.MAX_FAILED_ATTEMPTS + 1); i++) {
+        for (var i = 0; i < (eventStreamService.MAX_FAILED_ATTEMPTS + 1); i++) {
             request.reject({data:{status:0}}); // reject no connection.
-            request = q.defer(); // make a new promise in prep for the next request
-            scope.$digest(); // invoke the .then
-            timeout.flush(); // flush the waiting period.
+            request = $q.defer(); // make a new promise in prep for the next request
+            $scope.$digest(); // invoke the .then
+            $interval.flush(eventStreamService.SERVER_TIMEOUT + (1000 * 2)); // flush the waiting period.
         }
         
         expect(isBadConnection).toBe(true);
         
         // successful connection now
         request.resolve({data: {chunk:[],start:"s",end:"e"}});
-        request = q.defer();
-        scope.$digest();
+        request = $q.defer();
+        $scope.$digest();
         expect(isBadConnection).toBe(false);
     }));
 });

--- a/syweb/webclient/test/unit/presence-service.spec.js
+++ b/syweb/webclient/test/unit/presence-service.spec.js
@@ -1,5 +1,5 @@
 describe('PresenceService', function() {
-    var $q, $timeout;
+    var $q, $interval;
     
     var matrixService = {
         setUserPresence: function(state){},
@@ -26,9 +26,9 @@ describe('PresenceService', function() {
         module('mPresence');
     });
     
-    beforeEach(inject(function(_$q_, _$timeout_) {
-            $q = _$q_;
-            $timeout = _$timeout_;
+    beforeEach(inject(function(_$q_, _$interval_) {
+        $q = _$q_;
+        $interval = _$interval_;
     }));
     
     it('should start with the user as online.', inject(
@@ -47,7 +47,7 @@ describe('PresenceService', function() {
         spyOn(matrixService, "setUserPresence").and.returnValue(defer.promise);
         mPresence.start();
         defer.resolve({});
-        $timeout.flush(); // expire the timer
+        $interval.flush(mPresence.UNAVAILABLE_TIME);// expire the timer
         expect(matrixService.setUserPresence).toHaveBeenCalledWith(
             matrixService.presence.unavailable
         );
@@ -62,7 +62,7 @@ describe('PresenceService', function() {
         
         mPresence.stop();
         
-        $timeout.flush(); // expire the timer
+        $interval.flush(mPresence.UNAVAILABLE_TIME);// expire the timer
         expect(matrixService.setUserPresence).not.toHaveBeenCalledWith(
             matrixService.presence.unavailable
         );
@@ -76,7 +76,7 @@ describe('PresenceService', function() {
         defer.resolve({});
         expect(mPresence.getState()).toEqual(matrixService.presence.online);
         
-        $timeout.flush(); // expire the timer
+        $interval.flush(mPresence.UNAVAILABLE_TIME);// expire the timer
         expect(mPresence.getState()).toEqual(matrixService.presence.unavailable);
     }));
     
@@ -86,7 +86,7 @@ describe('PresenceService', function() {
         spyOn(matrixService, "setUserPresence").and.returnValue(defer.promise);
         mPresence.start();
         defer.resolve({}); // online
-        $timeout.flush(); // expire the timer
+        $interval.flush(mPresence.UNAVAILABLE_TIME); // expire the timer
         expect(mPresence.getState()).toEqual(matrixService.presence.unavailable);
         
         doc[0].onmousemove();

--- a/syweb/webclient/test/unit/typing-service.spec.js
+++ b/syweb/webclient/test/unit/typing-service.spec.js
@@ -1,5 +1,5 @@
 describe('TypingService', function() {
-    var $timeout, $q, $rootScope;
+    var $interval, $q, $rootScope;
 
     var matrixService = {
         setTyping: function(){}
@@ -12,8 +12,8 @@ describe('TypingService', function() {
         module('typingService');
     });
     
-    beforeEach(inject(function(_$timeout_, _$q_, _$rootScope_) {
-        $timeout = _$timeout_;
+    beforeEach(inject(function(_$interval_, _$q_, _$rootScope_) {
+        $interval = _$interval_;
         $q = _$q_;
         $rootScope = _$rootScope_;
     }));
@@ -52,7 +52,7 @@ describe('TypingService', function() {
         defer.resolve({});
         $rootScope.$digest();
         
-        $timeout.flush(); // annoyingly this flushes ALL THE TIMEOUTS :(
+        $interval.flush(typingService.USER_TIMEOUT_MS); // annoyingly this flushes ALL THE TIMEOUTS :(
         
         expect(matrixService.setTyping).toHaveBeenCalledWith(roomId, false);
     }));


### PR DESCRIPTION
End to end testing is testing your application live again a simulated user that interacts with the UI of the application. There is a framework specifically made for angular for testing e2e: Protractor.

When you run e2e-tests Protractor waits after each interaction with the site for the site to 'finish'. This means waiting for http-requests and timeouts. The matrix services like event-stream-service and event-handler-service blocks Protractor due to timeouts that's calling them self, resulting in endless timeout loops. 

This pull request change those blocking $timeouts to $interval ($interval does not block Protractor) which repeats only once. The change should not affect the users in any way, only Protractor. For those who have the matrix-angular-sdk as a dependency in their application, they should be able to run Protractor tests.

PS. The server timeout for the event-stream which is 30 sec will block Protractor for 30 sec and if running Protractor with default config, the spec will timeout. Though, if the timeout was changed to something shorter (3 sec for example) this would affect the server for example. This timeout constant should preferably be overridden by a mock module in the Protractor specs. 